### PR TITLE
Uses char-based API to improve the performance.

### DIFF
--- a/src/main/java/org/jboss/classfilewriter/annotations/ClassAnnotation.java
+++ b/src/main/java/org/jboss/classfilewriter/annotations/ClassAnnotation.java
@@ -41,7 +41,7 @@ public class ClassAnnotation implements WritableEntry {
 
     public ClassAnnotation(ConstPool constPool, String type, List<AnnotationValue> annotationValues) {
         this.type = type;
-        this.typeIndex = constPool.addUtf8Entry("L" + type.replace(".","/") + ";");
+        this.typeIndex = constPool.addUtf8Entry('L' + type.replace('.', '/') + ';');
         this.annotationValues = new ArrayList<AnnotationValue>(annotationValues);
     }
 

--- a/src/main/java/org/jboss/classfilewriter/code/CodeAttribute.java
+++ b/src/main/java/org/jboss/classfilewriter/code/CodeAttribute.java
@@ -216,9 +216,9 @@ public class CodeAttribute extends Attribute {
         writeShort(index);
         currentOffset += 3;
         if (arrayType.startsWith("[")) {
-            advanceFrame(currentFrame.replace("[" + arrayType));
+            advanceFrame(currentFrame.replace('[' + arrayType));
         } else {
-            advanceFrame(currentFrame.replace("[L" + arrayType + ";"));
+            advanceFrame(currentFrame.replace("[L" + arrayType + ';'));
         }
     }
 
@@ -1831,7 +1831,7 @@ public class CodeAttribute extends Attribute {
         if (!arrayType.startsWith("[")) {
             newType.append('L');
             newType.append(arrayType);
-            newType.append(";");
+            newType.append(';');
         } else {
             newType.append(arrayType);
         }

--- a/src/main/java/org/jboss/classfilewriter/code/StackState.java
+++ b/src/main/java/org/jboss/classfilewriter/code/StackState.java
@@ -52,7 +52,7 @@ public class StackState {
 
     public StackState(String exceptionType, ConstPool constPool) {
         this.contents = new ArrayList<StackEntry>(1);
-        this.contents.add(new StackEntry(StackEntryType.OBJECT, "L" + exceptionType + ";", constPool));
+        this.contents.add(new StackEntry(StackEntryType.OBJECT, 'L' + exceptionType + ';', constPool));
         this.constPool = constPool;
     }
 

--- a/src/main/java/org/jboss/classfilewriter/util/DescriptorUtils.java
+++ b/src/main/java/org/jboss/classfilewriter/util/DescriptorUtils.java
@@ -45,7 +45,7 @@ public class DescriptorUtils {
      * e.g. java.lang.String => Ljava/lang/String;
      */
     public static String makeDescriptor(String className) {
-        String repl = className.replace(".", "/");
+        String repl = className.replace('.', '/');
         return 'L' + repl + ';';
     }
 
@@ -69,7 +69,7 @@ public class DescriptorUtils {
         } else if (boolean.class.equals(c)) {
             return BOOLEAN_CLASS_DESCRIPTOR;
         } else if (c.isArray()) {
-            return c.getName().replace(".", "/");
+            return c.getName().replace('.', '/');
         } else
         // normal object
         {
@@ -82,8 +82,8 @@ public class DescriptorUtils {
         for (Class<?> p : c.getParameterTypes()) {
             desc.append(DescriptorUtils.makeDescriptor(p));
         }
-        desc.append(")");
-        desc.append("V");
+        desc.append(')');
+        desc.append('V');
         return desc.toString();
     }
 
@@ -115,7 +115,7 @@ public class DescriptorUtils {
                     }
                 } else {
                     if (arraystart == -1) {
-                        type = methodDescriptor.charAt(i) + "";
+                        type = String.valueOf(methodDescriptor.charAt(i));
                     } else {
                         type = methodDescriptor.substring(arraystart, i + 1);
                     }
@@ -185,7 +185,7 @@ public class DescriptorUtils {
         for (Class<?> p : m.getParameterTypes()) {
             desc.append(DescriptorUtils.makeDescriptor(p));
         }
-        desc.append(")");
+        desc.append(')');
         desc.append(DescriptorUtils.makeDescriptor(m.getReturnType()));
         return desc.toString();
     }
@@ -195,7 +195,7 @@ public class DescriptorUtils {
         for (String p : parameters) {
             desc.append(p);
         }
-        desc.append(")");
+        desc.append(')');
         desc.append(returnType);
         return desc.toString();
     }

--- a/src/main/java/org/jboss/classfilewriter/util/SignatureBuilder.java
+++ b/src/main/java/org/jboss/classfilewriter/util/SignatureBuilder.java
@@ -78,7 +78,7 @@ public class SignatureBuilder {
             builder.append('.');
             builder.append(clazz.getSimpleName());
         } else {
-            builder.append("L");
+            builder.append('L');
             builder.append(clazz.getName().replace('.', '/'));
         }
 

--- a/src/main/java/org/jboss/classfilewriter/util/Signatures.java
+++ b/src/main/java/org/jboss/classfilewriter/util/Signatures.java
@@ -223,7 +223,7 @@ public final class Signatures {
         } else if (clazz.isArray()) {
             builder.append(encodeClassName(clazz.getName()));
         } else {
-            builder.append(classTypeBase(clazz.getName()) + SEMICOLON);
+            builder.append(classTypeBase(clazz.getName())).append(SEMICOLON);
         }
     }
 
@@ -238,7 +238,7 @@ public final class Signatures {
     }
 
     private static String encodeClassName(String className) {
-        return className.replace(".", "/");
+        return className.replace('.', '/');
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Changed code to use char-base API to improve the performance. In particular replacing calls to String.replace(CharSequence, CharSequence) by String.replace(char, char) should reduce the number of created objects and improve the performance because the first method uses RegExp to perform the replacement.
