### PR TITLE
StackState - always use internal binary name in descriptor

### DIFF
--- a/src/main/java/org/jboss/classfilewriter/code/CodeAttribute.java
+++ b/src/main/java/org/jboss/classfilewriter/code/CodeAttribute.java
@@ -328,7 +328,7 @@ public class CodeAttribute extends Attribute {
      * Do not use Descriptor format (e.g. Ljava/lang/Object;), the correct form is just java/lang/Object or java.lang.Object
      */
     public void checkcast(String className) {
-        if(className.endsWith(";")) {
+        if (!className.startsWith("[") && className.endsWith(";")) {
             throw new RuntimeException("Invalid cast format " + className);
         }
         className = className.replace(".", "/");

--- a/src/main/java/org/jboss/classfilewriter/code/StackState.java
+++ b/src/main/java/org/jboss/classfilewriter/code/StackState.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.jboss.classfilewriter.InvalidBytecodeException;
 import org.jboss.classfilewriter.constpool.ConstPool;
+import org.jboss.classfilewriter.util.DescriptorUtils;
 
 
 /**
@@ -52,7 +53,7 @@ public class StackState {
 
     public StackState(String exceptionType, ConstPool constPool) {
         this.contents = new ArrayList<StackEntry>(1);
-        this.contents.add(new StackEntry(StackEntryType.OBJECT, "L" + exceptionType + ";", constPool));
+        this.contents.add(new StackEntry(StackEntryType.OBJECT, DescriptorUtils.makeDescriptor(exceptionType), constPool));
         this.constPool = constPool;
     }
 

--- a/src/test/java/org/jboss/classfilewriter/test/bytecode/handler/ExceptionHandlerTest.java
+++ b/src/test/java/org/jboss/classfilewriter/test/bytecode/handler/ExceptionHandlerTest.java
@@ -17,12 +17,12 @@
  */
 package org.jboss.classfilewriter.test.bytecode.handler;
 
-import junit.framework.Assert;
-
 import org.jboss.classfilewriter.code.CodeAttribute;
 import org.jboss.classfilewriter.code.ExceptionHandler;
 import org.jboss.classfilewriter.test.bytecode.MethodTester;
 import org.junit.Test;
+
+import junit.framework.Assert;
 
 public class ExceptionHandlerTest {
     public static Integer[] VALUE;
@@ -54,6 +54,21 @@ public class ExceptionHandlerTest {
         ca.iconst(20);
         ca.returnInstruction();
         Assert.assertEquals(200, (int) mt.invoke());
+    }
+
+    @Test
+    public void testNonInternalBinaryName() {
+        MethodTester<Integer> mt = new MethodTester<Integer>(int.class);
+        CodeAttribute ca = mt.getCodeAttribute();
+        ExceptionHandler handler = ca.exceptionBlockStart("java.lang.RuntimeException");
+        ca.getstatic(getClass().getName(), "VALUE", "[Ljava/lang/Integer;");
+        ca.arraylength();
+        ca.returnInstruction();
+        ca.exceptionBlockEnd(handler);
+        ca.exceptionHandlerStart(handler);
+        ca.iconst(1);
+        ca.returnInstruction();
+        Assert.assertEquals(1, (int) mt.invoke());
     }
 
 }


### PR DESCRIPTION
- see also #12