### PR TITLE
Have typeIndex be an cp index to descriptor of the enum type in EnumAnnotationValue

### DIFF
--- a/src/main/java/org/jboss/classfilewriter/annotations/EnumAnnotationValue.java
+++ b/src/main/java/org/jboss/classfilewriter/annotations/EnumAnnotationValue.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import org.jboss.classfilewriter.constpool.ConstPool;
 import org.jboss.classfilewriter.util.ByteArrayDataOutputStream;
+import org.jboss.classfilewriter.util.DescriptorUtils;
 
 /**
  * An enum annotation value
@@ -38,7 +39,7 @@ public class EnumAnnotationValue extends AnnotationValue {
     public EnumAnnotationValue(ConstPool constPool, String name, Enum<?> value) {
         super(constPool, name);
         this.valueIndex = constPool.addUtf8Entry(value.name());
-        this.typeIndex = constPool.addUtf8Entry(value.getDeclaringClass().getName());
+        this.typeIndex = constPool.addUtf8Entry(DescriptorUtils.makeDescriptor(value.getDeclaringClass().getName()));
     }
 
     public EnumAnnotationValue(ConstPool constPool, String name, String enumType, String enumValue) {


### PR DESCRIPTION
Previously, `typeIndex` was an index to internal name of the enum type.
This does ahdere to JVMS.

Relevant snippets from JVMS:
type_name_index
The constant_pool entry at that index must be a CONSTANT_Utf8_info
structure (§4.4.7) representing a field descriptor (§4.3.2).

https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.16.1

The issue causes `IllegalArgumentException`  when reading generated classes with ASM 6.1.1.
