### PR TITLE
Revert "[WFLY-11566] ClassMethod: Retain generic parameters information"

### DIFF
--- a/src/main/java/org/jboss/classfilewriter/ClassFile.java
+++ b/src/main/java/org/jboss/classfilewriter/ClassFile.java
@@ -36,7 +36,6 @@ import org.jboss.classfilewriter.attributes.Attribute;
 import org.jboss.classfilewriter.constpool.ConstPool;
 import org.jboss.classfilewriter.util.ByteArrayDataOutputStream;
 import org.jboss.classfilewriter.util.DescriptorUtils;
-import org.jboss.classfilewriter.util.Signatures;
 
 /**
  * @author Stuart Douglas
@@ -196,7 +195,6 @@ public class ClassFile implements WritableEntry {
         ClassMethod classMethod = addMethod(method.getModifiers() & (~AccessFlag.ABSTRACT) & (~AccessFlag.NATIVE), method
                 .getName(), DescriptorUtils.makeDescriptor(method.getReturnType()), DescriptorUtils.parameterDescriptors(method
                 .getParameterTypes()));
-        classMethod.setSignature(Signatures.methodSignature(method));
         for (Class<?> e : method.getExceptionTypes()) {
             classMethod.addCheckedExceptions((Class<? extends Exception>) e);
         }


### PR DESCRIPTION
This reverts commit ea5c534b0edd1c581e1a0106286c18e1f0c5806a.

The commit was part of previous attempt to solve https://issues.redhat.com/browse/WFLY-11566 but it introduced multiple other problem with Weld. Different solution was taken for the WFLY issue and this should be reverted. Correct @tadamski?